### PR TITLE
Make sure iptables service is not started

### DIFF
--- a/deploy/modules/roles/manifests/middleware.pp
+++ b/deploy/modules/roles/manifests/middleware.pp
@@ -1,5 +1,8 @@
 class roles::middleware {
-  service{"iptables": ensure => stopped}
+  service{"iptables":
+    ensure => stopped,
+    enable => false
+  }
 
   class{"repos": } ->
 


### PR DESCRIPTION
Make sure iptables service is not started even after reload or halt of middleware node.